### PR TITLE
Use relative path & create empty directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Part of the training data is released in [GL3D](https://github.com/lzx551402/GL3
 To get started, clone the repo and download the pretrained model (take `ContextDesc++` as an example):
 ```bash
 git clone https://github.com/lzx551402/contextdesc.git && \
-cd /local/contextdesc/pretrained && \
+mkdir ./contextdesc/pretrained && \
+cd ./contextdesc/pretrained && \
 wget https://research.altizure.com/data/contextdesc_models/contextdesc_pp.tar && \
 tar -xvf contextdesc_pp.tar
 ```
@@ -61,7 +62,7 @@ tar -xvf contextdesc_pp.tar
 then simply call:
 
 ```bash
-cd /local/contextdesc && python image_matching.py
+cd ../contextdesc && python image_matching.py
 ```
 
 The matching results from SIFT features (top), raw local features (middle) and augmented features (bottom) will be displayed. 
@@ -85,7 +86,7 @@ Next, configure the data paths (`data_root`, `dump_root` and `submission_root`) 
 Then call the evaluation script by:
 
 ```bash
-cd /local/contextdesc && python evaluations.py --config configs/imw2019_eval.yaml
+cd path/to/contextdesc && python evaluations.py --config configs/imw2019_eval.yaml
 ```
 
 You may then compress and submit the results to the challenge website. 


### PR DESCRIPTION
Obviously you are using absolute path (`/local/contestdesc`) in scripts, but `/local` is not accessible to everyone, especially the people using a non-sudoer account (and thus cannot write to `/`), running the program on windows or some other reason. Using relative paths is somewhat more convenient.

And about the `pretrained` directory, I suppose that you've created it on your own machine and `git add`ed it. However, `git` ignores empty directories.  